### PR TITLE
Update OWP_PlanetManager.cs

### DIFF
--- a/src/OtherWorldsProgram/OWP_PlanetManager.cs
+++ b/src/OtherWorldsProgram/OWP_PlanetManager.cs
@@ -25,7 +25,7 @@ namespace NiakoKerbalMods
 				get { return (PLANETS != null && PLANETS.Count > 2) ? PLANETS[1] : null; }
 			}
 
-			private static string[] PLANETS_NAMES = {"OWR1", "OWR2"};
+			private static string[] PLANETS_NAMES = {"Owr1", "Owr2"};
 
 			private static bool FirstStart = true;
 


### PR DESCRIPTION
Renames OWR1 and OWR2 to Owr1 and Owr2 which fixes an issue with ContractConfigurator incorrectly parsing the biomes due to the celestial bodies having multiple uppercase letters.